### PR TITLE
Add Feed Me importing hooks for Address fieldtype, and include multip…

### DIFF
--- a/vzaddress/VzAddressPlugin.php
+++ b/vzaddress/VzAddressPlugin.php
@@ -25,4 +25,38 @@ class VzAddressPlugin extends BasePlugin
     {
         return 'http://elivz.com';
     }
+
+    public function registerFeedMeMappingOptions()
+    {
+        return array(
+            'VzAddress' => 'vzaddress/_plugins/feedMeOptions',
+        );
+    }
+
+    public function prepForFeedMeFieldType($field, &$data, $handle)
+    {
+        // Ensure it's a VzAddress field
+        if ($field->type == 'VzAddress') {
+
+            // Initialize content array
+            $content = array();
+
+            // Separate field handle & subfield handle
+            if (preg_match('/^(.*)\[(.*)]$/', $handle, $matches)) {
+                $fieldHandle    = $matches[1];
+                $subFieldHandle = $matches[2];
+
+                // Ensure address array exists
+                if (!array_key_exists($fieldHandle, $content)) {
+                    $content[$fieldHandle] = array();
+                }
+
+                // Set value to subfield of correct address array
+                $content[$fieldHandle][$subFieldHandle] = $data[$fieldHandle];
+            }
+
+            // Modify data
+            $data = $content;
+        }
+    }
 }

--- a/vzaddress/templates/_plugins/feedMeOptions.html
+++ b/vzaddress/templates/_plugins/feedMeOptions.html
@@ -1,0 +1,17 @@
+{{ _self.generateOption('Address (Street)', 'street', field, key, feed) }}
+{{ _self.generateOption('Address (Street 2)', 'street2', field, key, feed) }}
+{{ _self.generateOption('Address (City)', 'city', field, key, feed) }}
+{{ _self.generateOption('Address (State/Province)', 'region', field, key, feed) }}
+{{ _self.generateOption('Address (Postal Code)', 'postalCode', field, key, feed) }}
+{{ _self.generateOption('Address (Country)', 'country', field, key, feed) }}
+
+{% macro generateOption(label, value, field, key, feed) %}
+    {% set selected = '' %}
+    {% set value = field.handle ~ '[' ~ value ~ ']' %}
+
+    {% if key in feed.fieldMapping | keys %}
+        {% set selected = (feed.fieldMapping[key] == value) ? 'selected' : '' %}
+    {% endif %}
+
+    <option {{ selected }} value="{{ value }}">{{ label }}</option>
+{% endmacro %}


### PR DESCRIPTION
Hey Eli - love your plugin, use it all the time, great work!

With the recent changes to Feed Me [1.4.0](https://github.com/engram-design/FeedMe/releases/tag/1.4.0), you can now include support in third-party plugins. While any fieldtype that supports a single value is okay as-is, for fieldtypes that have multiple bits of data, its a bit more complicated.

You can read more about the functions I've added on the [Wiki page](https://github.com/engram-design/FeedMe/wiki/Hooks). This PR is a tested and working example.

No pressure at all to add this, I just needed to support this for a recent project. Feel free to take it or leave it :smiley: 
