### PR TITLE
Fix for Issue #29 Google map API key logic

### DIFF
--- a/vzaddress/models/VzAddress_AddressModel.php
+++ b/vzaddress/models/VzAddress_AddressModel.php
@@ -179,7 +179,7 @@ class VzAddress_AddressModel extends BaseModel
     public function dynamicMap($params = array(), $icon = array()) {
         if (isset($params['key'])) {
             $key = $params['key'];
-        } elseif (!empty($settings['googleApiKey'])) {
+        } else {
             // fetch our plugin settings so we can use the api key
             $settings = craft()->plugins->getPlugin("vzAddress")->getSettings();
             $key = $settings['googleApiKey'];


### PR DESCRIPTION
$settings isn't available yet so just use a plain else.

Fixes the "Google API key is required" issue in #29 