### PR TITLE
Craft 5 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     }
   },
   "require": {
-    "craftcms/cms": "^4.0.0",
+    "craftcms/cms": "^4.0|^5.0",
     "ext-json": "*"
   },
   "require-dev": {

--- a/src/fields/Address.php
+++ b/src/fields/Address.php
@@ -114,7 +114,7 @@ class Address extends Field
      *
      * @return mixed The prepared field value
      */
-    public function normalizeValue(mixed $value, ElementInterface $element = null): mixed
+    public function normalizeValue(mixed $value, ?\craft\base\ElementInterface $element = null): mixed
     {
         if (is_string($value) && !empty($value)) {
             $value = Json::decode($value);
@@ -160,7 +160,7 @@ class Address extends Field
      *
      * @return string The input HTML.
      */
-    public function getInputHtml($value, ?ElementInterface $element = null): string
+    public function getInputHtml(mixed $value, ?ElementInterface $element = null): string
     {
         // Register our asset bundle
         Craft::$app->getView()->registerAssetBundle(FieldAsset::class);

--- a/src/models/Address.php
+++ b/src/models/Address.php
@@ -471,11 +471,11 @@ class Address extends Model
                     if ($key == 'color') {
                         $value = str_replace('#', '0x', $value);
                     }
-                    $declaration[] .= "{$key}:{$value}";
+                    $declaration[] = "{$key}:{$value}";
                 }
             }
 
-            $output .= '&style=' . implode($declaration, '|');
+            $output .= '&style=' . implode('|', $declaration);
         }
 
         return $output;


### PR DESCRIPTION
### Changed

- Minor changes from running Rector
- Update composer `require` to support Craft 4 or 5, since the plugin code supports both as-is